### PR TITLE
Python3 urllib.error resolved by adding header parameter

### DIFF
--- a/jotform.py
+++ b/jotform.py
@@ -55,7 +55,9 @@ class JotformAPIClient:
             self._log(params)
 
         headers = {
-            'apiKey': self.__apiKey
+            'apiKey': self.__apiKey,
+            'User-Agent': 'Mozilla/5.0'
+            
         }
 
         if (method == 'GET'):


### PR DESCRIPTION
Python urllib.error.httperror: http error 403: forbidden
The easy way to resolve the error is by passing a valid user-agent as a header parameter. Added 'User-Agent': 'Mozilla/5.0' to the headers.